### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/Games/Keys/pyj2d/color.py
+++ b/Games/Keys/pyj2d/color.py
@@ -25,13 +25,13 @@ class Color(_Color):
         """
         Return string representation of Color object.
         """
-        return "(%d,%d,%d,%d)" % (self.getRed(), self.getGreen(), self.getBlue(), self.getAlpha())
+        return "({0:d},{1:d},{2:d},{3:d})".format(self.getRed(), self.getGreen(), self.getBlue(), self.getAlpha())
 
     def __str__(self):
         """
         Return string representation of Color object.
         """
-        return "(%d,%d,%d,%d)" % (self.getRed(), self.getGreen(), self.getBlue(), self.getAlpha())
+        return "({0:d},{1:d},{2:d},{3:d})".format(self.getRed(), self.getGreen(), self.getBlue(), self.getAlpha())
 
     def __getattr__(self, attr):
         """

--- a/Games/Keys/pyj2d/event.py
+++ b/Games/Keys/pyj2d/event.py
@@ -292,10 +292,10 @@ class Event(object):
             """
             Return string representation of Event object.
             """
-            return "%s(%s-UserEvent %r)" % (self.__class__, self.type, self.attr)
+            return "{0!s}({1!s}-UserEvent {2!r})".format(self.__class__, self.type, self.attr)
 
         def __setattr__(self, attr, value):
-            raise AttributeError, ("'Event' object has no attribute '%s'" % attr)
+            raise AttributeError, ("'Event' object has no attribute '{0!s}'".format(attr))
 
 
     class JEvent(object):
@@ -325,7 +325,7 @@ class Event(object):
             Return string representation of Event object.
             """
             try:
-                return "%s(%s)" % (self.__class__, self.event.toString())
+                return "{0!s}({1!s})".format(self.__class__, self.event.toString())
             except AttributeError:      #User Event
                 return self.event.__repr__()
 
@@ -362,12 +362,12 @@ class Event(object):
                     try:
                         return self.event.__getattribute__('attr')[attr]
                     except AttributeError:
-                        raise AttributeError, ("'Event' object has no attribute '%s'" % attr)
+                        raise AttributeError, ("'Event' object has no attribute '{0!s}'".format(attr))
                     except KeyError:
-                        raise AttributeError, ("'Event' object has no attribute '%s'" % attr)
+                        raise AttributeError, ("'Event' object has no attribute '{0!s}'".format(attr))
 
         def __setattr__(self, attr, value):     #0.22
-            raise AttributeError, ("'Event' object has no attribute '%s'" % attr)
+            raise AttributeError, ("'Event' object has no attribute '{0!s}'".format(attr))
 
         def getEvent(self):
             """

--- a/Games/Keys/pyj2d/font.py
+++ b/Games/Keys/pyj2d/font.py
@@ -108,7 +108,7 @@ class Font(JFont):
         """
         Return string representation of Font object.
         """
-        return "%s(%r)" % (self.__class__, self.__dict__)
+        return "{0!s}({1!r})".format(self.__class__, self.__dict__)
 
     def render(self, text, antialias, color, background=None):
         """

--- a/Games/Keys/pyj2d/mask.py
+++ b/Games/Keys/pyj2d/mask.py
@@ -95,7 +95,7 @@ class Mask(object):
         """
         Return string representation of Mask object.
         """
-        return "%s(%r)" % (self.__class__, self.__dict__)
+        return "{0!s}({1!r})".format(self.__class__, self.__dict__)
 
     def get_size(self):
         """

--- a/Games/Keys/pyj2d/rect.py
+++ b/Games/Keys/pyj2d/rect.py
@@ -111,7 +111,7 @@ class Rect(Rectangle):
         """
         Return string representation of Rect object.
         """
-        return "%s(%s)" % (self.__class__, self.toString())
+        return "{0!s}({1!s})".format(self.__class__, self.toString())
 
     def __getattr__(self, attr):
         """

--- a/Games/Keys/pyj2d/sprite.py
+++ b/Games/Keys/pyj2d/sprite.py
@@ -37,7 +37,7 @@ class Sprite(object):
         """
         Return string representation of Sprite object.
         """
-        return "%s(in %d groups)" % (self.__class__, len(self.groups()))
+        return "{0!s}(in {1:d} groups)".format(self.__class__, len(self.groups()))
 
     def add(self, *groups):
         """
@@ -138,7 +138,7 @@ class Group(object):
         """
         Return string representation of Group object.
         """
-        return "%s(%d sprites)" % (self.__class__, len(self._sprites))
+        return "{0!s}({1:d} sprites)".format(self.__class__, len(self._sprites))
 
     def __iter__(self):
         """

--- a/Games/Keys/pyj2d/surface.py
+++ b/Games/Keys/pyj2d/surface.py
@@ -78,7 +78,7 @@ class Surface(BufferedImage):
         """
         Return string representation of Surface object.
         """
-        return "%s(%s, %r)" % (self.__class__, self.toString(), self.__dict__)
+        return "{0!s}({1!s}, {2!r})".format(self.__class__, self.toString(), self.__dict__)
 
     def get_size(self):
         """

--- a/SpeechRecognition/__init__.py
+++ b/SpeechRecognition/__init__.py
@@ -168,7 +168,7 @@ class Recognizer(AudioSource):
             os.chmod(flac_converter, stat_info.st_mode | stat.S_IEXEC)
         except OSError: pass
 
-        process = subprocess.Popen("\"%s\" --stdout --totally-silent --best -" % flac_converter, stdin=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
+        process = subprocess.Popen("\"{0!s}\" --stdout --totally-silent --best -".format(flac_converter), stdin=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
         flac_data, stderr = process.communicate(wav_data)
         return flac_data
 
@@ -298,8 +298,8 @@ class Recognizer(AudioSource):
         """
         assert isinstance(audio_data, AudioData), "Data must be audio data"
 
-        url = "http://www.google.com/speech-api/v2/recognize?client=chromium&lang=%s&key=%s" % (self.language, self.key)
-        self.request = Request(url, data = audio_data.data, headers = {"Content-Type": "audio/x-flac; rate=%s" % audio_data.rate})
+        url = "http://www.google.com/speech-api/v2/recognize?client=chromium&lang={0!s}&key={1!s}".format(self.language, self.key)
+        self.request = Request(url, data = audio_data.data, headers = {"Content-Type": "audio/x-flac; rate={0!s}".format(audio_data.rate)})
         
         # check for invalid key response from the server
         try:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bowbahdoe:Carol?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bowbahdoe:Carol?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
